### PR TITLE
Add option to have different parts requirement for different mechs, based on weight

### DIFF
--- a/BrokenSalvagedMechs/BrokenSalvagedMechs/AdjustedMechAssembly.cs
+++ b/BrokenSalvagedMechs/BrokenSalvagedMechs/AdjustedMechAssembly.cs
@@ -1,14 +1,23 @@
-﻿using Harmony;
+﻿using System;
+using Harmony;
 using System.Reflection;
 
 namespace AdjustedMechAssembly {
     public class AdjustedMechAssembly {
         internal static string ModDirectory;
         public static void Init(string directory, string settingsJSON) {
-            var harmony = HarmonyInstance.Create("de.morphyum.AdjustedMechAssembly");
-            harmony.PatchAll(Assembly.GetExecutingAssembly());
+            try
+            {
+                var harmony = HarmonyInstance.Create("de.morphyum.AdjustedMechAssembly");
+                harmony.PatchAll(Assembly.GetExecutingAssembly());
 
-            ModDirectory = directory;
+                ModDirectory = directory;
+            }
+            catch (Exception e)
+            {
+                FileLog.Log(e.ToString());
+                Logger.LogError(e);
+            }
         }
     }
 }

--- a/BrokenSalvagedMechs/BrokenSalvagedMechs/AdjustedMechAssembly.csproj
+++ b/BrokenSalvagedMechs/BrokenSalvagedMechs/AdjustedMechAssembly.csproj
@@ -39,18 +39,19 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\BATTLETECH\BattleTech_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net35\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\GOG Galaxy\Games\BATTLETECH\BattleTech_Data\Managed\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\GOG Galaxy\Games\BATTLETECH\BattleTech_Data\Managed\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\GOG Galaxy\Games\BATTLETECH\BattleTech_Data\Managed\UnityEngine.UI.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AdjustedMechAssembly.cs" />

--- a/BrokenSalvagedMechs/BrokenSalvagedMechs/Helper.cs
+++ b/BrokenSalvagedMechs/BrokenSalvagedMechs/Helper.cs
@@ -1,21 +1,84 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using BattleTech;
 
 namespace AdjustedMechAssembly {
-    public class Helper {
-
-        public static Settings LoadSettings() {
-            try {
-                using (StreamReader r = new StreamReader($"{AdjustedMechAssembly.ModDirectory}/settings.json")) {
-                    string json = r.ReadToEnd();
-                    return JsonConvert.DeserializeObject<Settings>(json);
+    public static class Helper
+    {
+        private static Settings _settings;
+        public static Settings Settings
+        {
+            get
+            {
+                try
+                {
+                    if (_settings == null)
+                    {
+                        using (StreamReader r = new StreamReader($"{AdjustedMechAssembly.ModDirectory}/settings.json"))
+                        {
+                            string json = r.ReadToEnd();
+                            _settings = JsonConvert.DeserializeObject<Settings>(json);
+                        }
+                    }
+                    return _settings;
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex);
+                    return null;
                 }
             }
-            catch (Exception ex) {
-                Logger.LogError(ex);
-                return null;
+        }
+
+        private static List<int> _partsByWeightTable;
+
+        public static List<int> PartsByWeightTable
+        {
+            get
+            {
+                if (_partsByWeightTable == null)
+                {
+                    _partsByWeightTable = new List<int>();
+                    int tonnage = 5;
+                    int partsRequired = 1;
+                    foreach (int cutoff in Settings.WeightThresholds)
+                    {
+                        while (tonnage <= cutoff)
+                        {
+                            _partsByWeightTable.Add(partsRequired);
+                            tonnage += 5;
+                        }
+
+                        ++partsRequired;
+                    }
+                }
+
+                return _partsByWeightTable;
             }
+        }
+
+        public static int GetMechPartsRequiredByWeight(ChassisDef chassisDef)
+        {
+            int index = ((int) chassisDef.Tonnage) / 5 - 1;
+            return index >= PartsByWeightTable.Count
+                ? PartsByWeightTable.Count
+                : index < 0
+                ? PartsByWeightTable[0]
+                : PartsByWeightTable[index];
+        }
+
+        public static int GetMechPartsRequired(this SimGameState simGameState, ChassisDef chassisDef)
+        {
+            return Settings.UseWeightThresholds 
+                ? GetMechPartsRequiredByWeight(chassisDef)
+                : simGameState.Constants.Story.DefaultMechPartMax;
+        }
+
+        public static int GetMechPartsRequired(this SimGameState simGameState, MechDef mechDef)
+        {
+            return simGameState.GetMechPartsRequired(mechDef.Chassis);
         }
     }
 }

--- a/BrokenSalvagedMechs/BrokenSalvagedMechs/HolderClasses.cs
+++ b/BrokenSalvagedMechs/BrokenSalvagedMechs/HolderClasses.cs
@@ -22,5 +22,8 @@ namespace AdjustedMechAssembly {
         public bool AssembleVariants = true;
         public bool AssembleMostParts = false;
         public List<string> VariantExceptions;
+
+        public bool UseWeightThresholds = false;
+        public List<int> WeightThresholds = new List<int> { 0, 0, 40, 45, 50, 60, 65, 70, 80, 85, 95, 95 };
     }
 }

--- a/BrokenSalvagedMechs/BrokenSalvagedMechs/Properties/AssemblyInfo.cs
+++ b/BrokenSalvagedMechs/BrokenSalvagedMechs/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("BrokenSalvagedMechs")]
-[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
 // übernehmen, indem Sie "*" eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/settings.json
+++ b/settings.json
@@ -14,5 +14,8 @@
 
         "RepairMechComponents" : true,
         "RepairComponentsFunctionalThreshold" : 0.25,
-        "RepairComponentsNonFunctionalThreshold" : 0.5
+        "RepairComponentsNonFunctionalThreshold" : 0.5,
+
+		"UseWeightThresholds" : false,
+		"PartsByWeight" : [0,0,40,45,50,60,65,70,80,95,95]
 }


### PR DESCRIPTION
This PR makes the following changes:

1. If the "most parts" option is chosen for the variant to be constructed, and there's more than one variant with equal most parts, then the variant that had the most parts BEFORE the current part was collected will be constructed. If there is more than one such variant with equal parts before the current part, then the one to be constructed will random (previously it just depended on which variant was first in the mech list).
2. Adds support for having a different number of parts based on mech, in particular weight, ignoring the difficulty options. By default the values given are:

Up to 40T: 3 parts
45T: 4 parts
50T: 5 parts
55-60T: 6 parts
65T: 7 parts
70T: 8 parts
75-80T: 9 parts
85-95T: 10 parts
100T: 12 parts

This makes the early game mechs relatively easy to obtain but makes the largest mechs quite hard. 

3. JSON settings are now read on startup not every time a mech part is found.
4. Added some logging.

Would be happy to merge this into your mod but I'm also happy to fork if you don't want to add this code and/or features to the mod.